### PR TITLE
adding ProcHot to CPUTune

### DIFF
--- a/CPUTune/CPUTune.cpp
+++ b/CPUTune/CPUTune.cpp
@@ -265,7 +265,7 @@ void CPUTune::disableProcHot()
 {
     const uint64_t cur = rdmsr64(0x1FC);
     
-    myLOG("disableProcHot: orig value: 0x%llx to 0x11x", cur, cur & 0xFFFFFFFE);
+    myLOG("disableProcHot: orig value: 0x%llx to 0x%11x", cur, cur & 0xFFFFFFFE);
     wrmsr64(0x1FC, rdmsr64(0x1FC) & 0xFFFFFFFE);
 }
 
@@ -273,7 +273,7 @@ void CPUTune::enableProcHot()
 {
     const uint64_t cur = rdmsr64(0x1FC);
     
-    myLOG("enableProcHot: orig value: 0x%llx to 0x11x", cur, cur | 0x1);
+    myLOG("enableProcHot: orig value: 0x%llx to 0x%11x", cur, cur | 0x1);
     wrmsr64(0x1FC, rdmsr64(0x1FC) | 0x1);
 }
 

--- a/CPUTune/CPUTune.cpp
+++ b/CPUTune/CPUTune.cpp
@@ -265,7 +265,7 @@ void CPUTune::disableProcHot()
 {
     const uint64_t cur = rdmsr64(0x1FC);
     
-    myLOG("disableProcHot: orig value: 0x%llx to 0x%11x", cur, cur & 0xFFFFFFFE);
+    myLOG("disableProcHot: orig value: 0x%llx to 0x%llx", cur, cur & 0xFFFFFFFE);
     wrmsr64(0x1FC, rdmsr64(0x1FC) & 0xFFFFFFFE);
 }
 
@@ -273,7 +273,7 @@ void CPUTune::enableProcHot()
 {
     const uint64_t cur = rdmsr64(0x1FC);
     
-    myLOG("enableProcHot: orig value: 0x%llx to 0x%11x", cur, cur | 0x1);
+    myLOG("enableProcHot: orig value: 0x%llx to 0x%llx", cur, cur | 0x1);
     wrmsr64(0x1FC, rdmsr64(0x1FC) | 0x1);
 }
 

--- a/CPUTune/CPUTune.hpp
+++ b/CPUTune/CPUTune.hpp
@@ -26,8 +26,10 @@ public:
     
 private:
     const char *turboBoostPath = nullptr;
+    const char *ProcHotPath = nullptr;
     const char *speedShiftPath = nullptr;
     bool enableIntelTurboBoost = true;
+    bool enableIntelProcHot = false;
     bool supportedSpeedShift = false;
     // As 64-ia-32-architectures-software-developer-vol-3b-part-2-manual (Vol. 3B 14-7)
     // Only RESET will clear this bit.
@@ -50,6 +52,9 @@ private:
     
     void enableTurboBoost(void);
     void disableTurboBoost(void);
+    
+    void enableProcHot(void);
+    void disableProcHot(void);
     
     void enableSpeedShift(void);
     void disableSpeedShift(void);

--- a/CPUTune/Info.plist
+++ b/CPUTune/Info.plist
@@ -36,9 +36,13 @@
 			<string>/tmp/CPUTuneSpeedShiftRT.conf</string>
 			<key>TurboBoostAtRuntime</key>
 			<string>/tmp/CPUTuneTurboBoostRT.conf</string>
+			<key>ProcHotAtRuntime</key>
+			<string>/tmp/CPUTuneProcHotRT.conf</string>
 			<key>EnableSpeedShift</key>
 			<true/>
 			<key>EnableTurboBoost</key>
+			<false/>
+			<key>EnableProcHot</key>
 			<false/>
 			<key>AllowUnrestrictedFS</key>
 			<false/>

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ CPUTune
 An open source kernel extension enables dynamic CPU performance tuning at runtime for macOS.
 
 #### Features
-- Allows tuning on or off Intel Turbo Boost for better battery life
-- Allows tuning on or off Intel Speed Shift for maximum performance
+- Allows turning on or off Intel Turbo Boost for better battery life
+- Allows turning on or off Intel Speed Shift for maximum performance
+- Allows turning on or off Intel Proc Hot for running without a battery. Please note that this is NOT recommended and can seriously damage your mac. Do at your own risk.
 - Implements TimerEvent-based responses for dynamical switching Turbo Boost and Speed Shift at runtime
 - Allows System Integrity Protection (SIP) control a bit easier via Info.plist setting 
 
@@ -16,6 +17,8 @@ An open source kernel extension enables dynamic CPU performance tuning at runtim
 #### Configuration
 - In terminal, type in ```echo "1">/tmp/CPUTuneTurboBoostRT.conf``` to enable turbo boost when CPUTune is loaded
 - In terminal, type in ```echo "0">/tmp/CPUTuneTurboBoostRT.conf``` to disable turbo boost when needed
+- In terminal, type in  ```echo "1">/tmp/CPUTuneProcHotRT.conf``` to enable proc hot when needed
+- In terminal, type in  ```echo "0">/tmp/CPUTuneProcHotRT.conf``` to siable proc hot when needed
 - In case you want a simplify command to switch turbo boost, change the `TurboBoostAtRuntime` in `CPUTune.kext/Contents/Info.plist`
 
 #### Contribution


### PR DESCRIPTION
BD_PROCHOT signal is used by Apple to force the CPU to the lowest possible frequency when the battery is removed from an Apple laptop.

This functionality to be used in conjunction with turboboost disabled (as not to overheat your CPUs) permit to regain a usable laptop while waiting for a new battery.